### PR TITLE
restructured for maintenance

### DIFF
--- a/.conanignore
+++ b/.conanignore
@@ -1,5 +1,6 @@
 .idea/*
 .github/*
+.venv/*
 venv/*
 tests/*
 .gitignore
@@ -7,6 +8,7 @@ LICENSE
 *README.md*
 *.DS_Store*
 *.pytest_cache*
+.*cache
 tmp/*
 tmp2/*
 .vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/tests/tmp*
+
 .vscode/
 
 # Byte-compiled / optimized / DLL files

--- a/extensions/commands/recipe/README.md
+++ b/extensions/commands/recipe/README.md
@@ -49,9 +49,9 @@ Creates an SBOM in CycloneDX 1.4 JSON format.
 **Dependencies**
 The command requires the package `cyclonedx-python-lib`.
 You can install it via
-
+<!-- keep in sync with the error message that asks for requirements/dependencies in `cmd_create_sbom.py` -->
 ```shellSession
-$ pip install "cyclonedx-python-lib>=4.0.1,<5.0.0"
+$ pip install 'cyclonedx-python-lib>=4.0.1,<5.0.0'
 ```
 
 Usage:

--- a/extensions/commands/recipe/cmd_create_sbom.py
+++ b/extensions/commands/recipe/cmd_create_sbom.py
@@ -1,11 +1,13 @@
 import os.path
 import sys
-from typing import TYPE_CHECKING, Iterable, List, Optional, Set, Tuple, Union
+from typing import (TYPE_CHECKING, Any, Iterable, List, Optional, Set, Tuple,
+                    Union)
 
 from conan.api.conan_api import ConanAPI
-from conan.api.output import ConanOutput, cli_out_write
+from conan.api.output import cli_out_write
 from conan.cli.args import common_graph_args, validate_common_graph_args
 from conan.cli.command import conan_command
+from conan.errors import ConanException
 
 if TYPE_CHECKING:
     from cyclonedx.model.bom import Bom
@@ -17,9 +19,8 @@ def format_cyclonedx_14_json(bom: 'Bom') -> None:
     cli_out_write(serialized_json)
 
 
-def format_text():
-    out = ConanOutput()
-    out.error("Format 'text' not supported")
+def format_text(_: Any) -> None:
+    raise ConanException("Format 'text' not supported")
 
 
 @conan_command(group="Recipe", formatters={

--- a/extensions/commands/recipe/cmd_create_sbom.py
+++ b/extensions/commands/recipe/cmd_create_sbom.py
@@ -1,122 +1,116 @@
 import os.path
 import sys
-from typing import Iterable, Optional, Tuple, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Iterable, List, Optional, Set, Tuple, Union
 
 from conan.api.conan_api import ConanAPI
-from conan.api.output import cli_out_write, ConanOutput
+from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.args import common_graph_args, validate_common_graph_args
 from conan.cli.command import conan_command
 
 if TYPE_CHECKING:
-    from conans.client.graph.graph import Node
+    from cyclonedx.model.bom import Bom
 
 
-def package_type_to_component_type(pt: str):
-    from cyclonedx.model.component import ComponentType
-    if pt is "application":
-        return ComponentType.APPLICATION
-    else:
-        return ComponentType.LIBRARY
-
-
-def licenses(ids: Union[Tuple[str], str]) -> Optional[Iterable]:
-    """
-    see https://cyclonedx.org/docs/1.4/json/#components_items_licenses
-    """
-    from cyclonedx.factory.license import LicenseFactory
-    from cyclonedx.model import LicenseChoice
-    if ids is None:
-        return None
-    if not isinstance(ids, tuple):
-        ids = [ids]
-    return [LicenseChoice(license=LicenseFactory().make_from_string(i)) for i in ids]
-
-
-def name(n: 'Node') -> str:
-    if n.name:
-        return n.name
-    else:
-        assert name.unknown_name_created is False, "multiple nodes have no name"
-        name.unknown_name_created = True
-        return "UNKNOWN"
-
-
-def package_url(node: 'Node', cached_name: str):
-    """
-    Creates a PURL following https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#conan
-    """
-    from packageurl import PackageURL
-    return PackageURL(
-        type="conan",
-        name=cached_name,
-        version=node.conanfile.version,
-        qualifiers={
-            "prev": node.prev,
-            "rref": node.ref.revision if node.ref else None,
-            "user": node.conanfile.user,
-            "channel": node.conanfile.channel,
-            "repository_url": node.remote.url if node.remote else None
-        })
-
-
-def create_component(n: 'Node'):
-    from cyclonedx.model.component import Component
-    from cyclonedx.model import ExternalReference, ExternalReferenceType, XsUri
-    name_ = name(n)
-    purl = package_url(n, name_)
-    result = Component(
-        type=package_type_to_component_type(n.conanfile.package_type),
-        name=name_,
-        version=n.conanfile.version,
-        licenses=licenses(n.conanfile.license),
-        bom_ref=purl.to_string(),
-        purl=purl,
-        description=n.conanfile.description
-    )
-    if n.conanfile.homepage:
-        result.external_references.add(ExternalReference(
-            type=ExternalReferenceType.WEBSITE,
-            url=XsUri(n.conanfile.homepage),
-        ))
-    return result
-
-
-def format_cyclonedx_14_json(result):
+def format_cyclonedx_14_json(bom: 'Bom') -> None:
     from cyclonedx.output.json import JsonV1Dot4
-    serialized_json = JsonV1Dot4(result).output_as_string()
+    serialized_json = JsonV1Dot4(bom).output_as_string()
     cli_out_write(serialized_json)
 
 
-def format_text(result):
+def format_text():
     out = ConanOutput()
     out.error("Format 'text' not supported")
-
-
-def me_as_tool():
-    from cyclonedx.model import ExternalReference, ExternalReferenceType, XsUri
-    from cyclonedx.model.bom import Tool
-    result = Tool(name="conan extension recipe:create-sbom")
-    result.external_references.add(ExternalReference(
-        type=ExternalReferenceType.WEBSITE,
-        url=XsUri("https://github.com/conan-io/conan-extensions")))
-    return result
 
 
 @conan_command(group="Recipe", formatters={
     "text": format_text,  # added by default in BaseConanCommand.__init__
     "cyclonedx_1.4_json": format_cyclonedx_14_json})
-def create_sbom(conan_api: ConanAPI, parser, *args):
-    """
-    creates an SBOM in CycloneDX 1.4 JSON format
-    """
+def create_sbom(conan_api: ConanAPI, parser, *args) -> 'Bom':
+    """Create a CycloneDX Software Bill of Materials (SBOM)"""
+
     try:
-        import cyclonedx
+        from cyclonedx.factory.license import LicenseFactory
+        from cyclonedx.model import (ExternalReference, ExternalReferenceType,
+                                     LicenseChoice, Tool, XsUri)
+        from cyclonedx.model.bom import Bom
+        from cyclonedx.model.component import Component, ComponentType
+        from packageurl import PackageURL
     except ModuleNotFoundError:
-        sys.stderr.write(
-            "The sbom extension needs an additional package, please run 'pip install cyclonedx-python-lib'\n")
+        # Assert on RUNTIME of the actual conan-command, that all requirements exist.
+        # Since conan loads all extensions when started, this check could prevent conan from running,
+        # if loading dependencies is performed outside the actual conan-command in global/module scope.
+        print('The sbom extension needs an additional package, please run:'
+              # keep in synk with the instructions in `README.md`
+              "pip install 'cyclonedx-python-lib>=4.0.1,<5.0.0'"
+              , sep='\n', file=sys.stderr)
         sys.exit(1)
-    from cyclonedx.model.bom import Bom
-    # BEGIN COPY FROM conan: cli/commands/graph.py
+
+    if TYPE_CHECKING:
+        from conans.client.graph.graph import Node
+
+    def package_type_to_component_type(pt: str) -> ComponentType:
+        return ComponentType.APPLICATION if pt == "application" else ComponentType.LIBRARY
+
+    def licenses(ls: Optional[Union[Tuple[str, ...], Set[str], List[str], str]]) -> Optional[Iterable[LicenseChoice]]:
+        """
+        see https://cyclonedx.org/docs/1.4/json/#components_items_licenses
+        """
+        if ls is None:
+            return None
+        if not isinstance(ls, (tuple, set, list)):
+            ls = [ls]
+        return [LicenseChoice(license=LicenseFactory().make_from_string(i)) for i in ls]
+
+    def name(node: 'Node') -> str:
+        if node.name:
+            return node.name
+        assert name.unknown_name_created is False, "multiple nodes have no name"
+        name.unknown_name_created = True
+        return "UNKNOWN"
+
+    def package_url(node: 'Node', cached_name: str) -> PackageURL:
+        """
+        Creates a PURL following https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#conan
+        """
+        return PackageURL(
+            type="conan",
+            name=cached_name,
+            version=node.conanfile.version,
+            qualifiers={
+                "prev": node.prev,
+                "rref": node.ref.revision if node.ref else None,
+                "user": node.conanfile.user,
+                "channel": node.conanfile.channel,
+                "repository_url": node.remote.url if node.remote else None
+            })
+
+    def create_component(n: 'Node') -> Component:
+        name_ = name(n)
+        purl = package_url(n, name_)
+        result = Component(
+            type=package_type_to_component_type(n.conanfile.package_type),
+            name=name_,
+            version=n.conanfile.version,
+            licenses=licenses(n.conanfile.license),
+            bom_ref=purl.to_string(),
+            purl=purl,
+            description=n.conanfile.description
+        )
+        if n.conanfile.homepage:
+            result.external_references.add(ExternalReference(
+                type=ExternalReferenceType.WEBSITE,
+                url=XsUri(n.conanfile.homepage),
+            ))
+        return result
+
+    def me_as_tool() -> Tool:
+        tool = Tool(name="conan extension recipe:create-sbom")
+        tool.external_references.add(ExternalReference(
+            type=ExternalReferenceType.WEBSITE,
+            url=XsUri("https://github.com/conan-io/conan-extensions")))
+        return tool
+
+    # region COPY FROM conan: cli/commands/graph.py
     common_graph_args(parser)
     args = parser.parse_args(*args)
     validate_common_graph_args(args)
@@ -139,7 +133,8 @@ def create_sbom(conan_api: ConanAPI, parser, *args):
         deps_graph = conan_api.graph.load_graph_requires(args.requires, args.tool_requires,
                                                          profile_host, profile_build, lockfile,
                                                          remotes, args.update)
-    # END COPY
+    # endregion COPY
+
     name.unknown_name_created = False
     components = {n: create_component(n) for n in deps_graph.nodes}
     bom = Bom()

--- a/tests/test_create_sbom.py
+++ b/tests/test_create_sbom.py
@@ -4,7 +4,7 @@ import pytest
 import tempfile
 import textwrap
 
-from tools import load, save, run
+from tools import save, run
 
 REQ_LIB = "gmp"
 REQ_VER = "6.2.1"
@@ -71,12 +71,29 @@ def create_conanfile_py():
     (create_conanfile_txt(), "conanfile.txt", ".", False),
     (str(), "doesnotmatter.txt", f"--requires {REQ_LIB}/{REQ_VER}", False)
 ])
-def test_create_sbom(conanfile_content, conanfile_name, sbom_command, test_metadata_name):
+def test_create_sbom_cdx14json(conanfile_content, conanfile_name, sbom_command, test_metadata_name):
     repo = os.path.join(os.path.dirname(__file__), "..")
     run(f"conan config install {repo}")
     run("conan profile detect")
     save(conanfile_name, conanfile_content)
 
-    run(f"conan recipe:create-sbom -f cyclonedx_1.4_json {sbom_command} > sbom.json")
-    sbom = json.loads(load("sbom.json"))
+    # discard all STD_ERR(2)
+    out = run(f"conan recipe:create-sbom -f cyclonedx_1.4_json {sbom_command} 2>/dev/null")
+    sbom = json.loads(out)
     _test_generated_sbom(sbom, test_metadata_name)
+
+
+@pytest.mark.parametrize("conanfile_content,conanfile_name,sbom_command,test_metadata_name", [
+    (create_conanfile_py(), "conanfile.py", ".", True),
+    (create_conanfile_txt(), "conanfile.txt", ".", False),
+    (str(), "doesnotmatter.txt", f"--requires {REQ_LIB}/{REQ_VER}", False)
+])
+def test_create_sbom_text(conanfile_content, conanfile_name, sbom_command, test_metadata_name):
+    repo = os.path.join(os.path.dirname(__file__), "..")
+    run(f"conan config install {repo}")
+    run("conan profile detect")
+    save(conanfile_name, conanfile_content)
+
+    # discard all STD_OUT(1)
+    out_err = run(f"conan recipe:create-sbom {sbom_command} >/dev/null", True)
+    assert "Format 'text' not supported" in out_err


### PR DESCRIPTION
* Restructured all functionality UNDER the callable conan_command `create_sbom`.
  This way all imports are not done when loading the module but later when the actual conan_command is called.
  This way the process is completely isolated, and does not affect any conan-startup-time processes.
* Consolidated imports for a smaller footprint
* Fixed and adjusted some type hints

when this is merged, it will be automatically be picked up downstream by https://github.com/conan-io/conan-extensions/pull/66